### PR TITLE
Update axi and common_cells dependencies

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -3,8 +3,8 @@ package:
   authors: ["Fabian Schuiki <fschuiki@iis.ee.ethz.ch>", "Florian Zaruba <zarubaf@iis.ee.ethz.ch>"]
 
 dependencies:
-  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.23.0 }
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.19.0 }
+  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.27.0 }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
 
 export_include_dirs:
   - include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated AXI dependency
+- Updated `common_cells` dependency to v1.21.0
 
 ## 0.1.3 - 2018-06-02
 ### Fixed

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -1,6 +1,6 @@
 axi/axi:
-  commit: v0.24.1
+  commit: v0.27.0
   domain: [cluster, soc]
 common_cells:
-  commit: v1.20.0
+  commit: v1.21.0
   domain: [cluster, soc]


### PR DESCRIPTION
A commit on the`ipapprox` branch is the one currently referenced in [`pulp_soc`](https://github.com/pulp-platform/pulp_soc), should this be integrated to master?