### PR TITLE
src/reg_mux.sv: Delete duplicated assignment

### DIFF
--- a/src/reg_mux.sv
+++ b/src/reg_mux.sv
@@ -66,6 +66,5 @@ module reg_mux #(
   assign out_req_o.write = out_payload.write;
   assign out_req_o.wdata = out_payload.wdata;
   assign out_req_o.wstrb = out_payload.wstrb;
-  assign out_req_o.valid = out_payload.valid;
 
 endmodule


### PR DESCRIPTION
The valid signal was being assigned to twice (Lines 61 and 69), which causes errors in compilation. Take the one from the stream arbiter valid port over the one from the payload.