### PR TITLE
apb_to_reg: Add option to properly latch forward path

### DIFF
--- a/src/apb_to_reg.sv
+++ b/src/apb_to_reg.sv
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright 2023 ETH Zurich and University of Bologna.
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at
@@ -10,7 +10,9 @@
 //
 // Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 
-module apb_to_reg (
+module apb_to_reg #(
+  parameter bit Feedthrough = 1'b1
+)(
   input  logic          clk_i,
   input  logic          rst_ni,
 
@@ -26,15 +28,40 @@ module apb_to_reg (
   REG_BUS.out  reg_o
 );
 
-  always_comb begin
-    reg_o.addr = paddr_i;
-    reg_o.write = pwrite_i;
-    reg_o.wdata = pwdata_i;
-    reg_o.wstrb = '1;
-    reg_o.valid = psel_i & penable_i;
-    pready_o = reg_o.ready;
-    pslverr_o = reg_o.error;
-    prdata_o = reg_o.rdata;
+  if (Feedthrough) begin : gen_feedthrough
+    // in this mode just using plain register interface makes more sense
+    always_comb begin
+      reg_o.addr = paddr_i;
+      reg_o.write = pwrite_i;
+      reg_o.wdata = pwdata_i;
+      reg_o.wstrb = '1;
+      reg_o.valid = psel_i & penable_i;
+      pready_o = reg_o.ready;
+      pslverr_o = reg_o.error;
+      prdata_o = reg_o.rdata;
+    end
+
+  end else begin : gen_apb_reg
+    // latch forward path as apb intends
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        reg_o.addr  <= '0;
+        reg_o.write <= '0;
+        reg_o.wdata <= '0;
+      end else if (psel_i && !penable_i) begin
+        reg_o.addr  <= paddr_i;
+        reg_o.write <= pwrite_i;
+        reg_o.wdata <= pwdata_i;
+      end
+    end
+
+    always_comb begin
+      reg_o.valid = psel_i & penable_i;
+      reg_o.wstrb = '1;
+      pready_o = reg_o.ready;
+      pslverr_o = reg_o.error;
+      prdata_o = reg_o.rdata;
+    end
   end
 endmodule
 


### PR DESCRIPTION
APB sel is meant to help you latch the addr, wdata and write. Feeding these signals through means basically repurposing apb to work like register interface.

Add option to allow you to do the request APB style with latching. Since there a bunch of quite broken APB masters out there which will break with this change we keep it in feedthrough mode by default.