### PR TITLE
Remov AND between input ready and valid to solve timing loops

### DIFF
--- a/src/reg_to_tlul.sv
+++ b/src/reg_to_tlul.sv
@@ -28,7 +28,7 @@ module reg_to_tlul #(
 );
 
 
-  assign tl_o.a_valid    = reg_req_i.valid & tl_i.a_ready;
+  assign tl_o.a_valid    = reg_req_i.valid;
   assign tl_o.a_opcode   = reg_req_i.write ? PutFullData : Get;
   assign tl_o.a_param    = '0;
   assign tl_o.a_size     = 'h2;


### PR DESCRIPTION
Fix protocol assign that might result in timing loops. The master and slave devices must take care of respecting the protocol, while the interface should only assign the various signals. See #37 .

