### PR TITLE
axi_to_reg_v2: Use `RegDataWidth` for output multiplexing

### DIFF
--- a/src/axi_to_reg_v2.sv
+++ b/src/axi_to_reg_v2.sv
@@ -223,7 +223,7 @@ module axi_to_reg_v2 #(
   reg_mux #(
     .NoPorts( NumBanks     ),
     .AW     ( AxiAddrWidth ),
-    .DW     ( AxiDataWidth ),
+    .DW     ( RegDataWidth ),
     .req_t  ( reg_req_t    ),
     .rsp_t  ( reg_rsp_t    )
   ) i_reg_mux (


### PR DESCRIPTION
Was getting lint error in reg_mux. Saw that reg_mux at end was using AxiDataWidth instead of RegDataWidth when it's inputs and outputs were both reg_req_t and reg_resp_t respectively. 