### PR TITLE
README.md: Bender documentation out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This repository contains a simple register interface definition as well as proto
 
 We re-use lowrisc's register file generator to generate arbitrary configuration registers from an `hjson` description. See the the [tool's description](https://opentitan.org/book/util/reggen/index.html) for further usage details.
 
-We use the [bender import tool](https://github.com/pulp-platform/bender#import-----copy-files-from-dependencies-that-do-not-support-bender) (`>v0.26.0`) to get the sources and apply our custom patches on top.
+We use the [bender import tool](https://github.com/pulp-platform/bender#import-----copy-files-from-dependencies-that-do-not-support-bender) (`>v0.27.0`) to get the sources and apply our custom patches on top.
 
-    curl --proto '=https' --tlsv1.2 https://pulp-platform.github.io/bender/init -sSf | sh -s -- 0.26.0
+    curl --proto '=https' --tlsv1.2 https://pulp-platform.github.io/bender/init -sSf | sh -s -- 0.28.1
     ./bender vendor init
 
 to re-vendor.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ We re-use lowrisc's register file generator to generate arbitrary configuration 
 We use the [bender import tool](https://github.com/pulp-platform/bender#import-----copy-files-from-dependencies-that-do-not-support-bender) (`>v0.26.0`) to get the sources and apply our custom patches on top.
 
     curl --proto '=https' --tlsv1.2 https://pulp-platform.github.io/bender/init -sSf | sh -s -- 0.26.0
-    ./bender import --refetch
+    ./bender vendor init
 
 to re-vendor.


### PR DESCRIPTION
Dear Maintainers,
Thanks for providing this repository.
We use a non supported OS, so the bender command fails to download version 0.26, and instead downloads 0.28.1. For that version, the import subcommand of bender has been replaced by the vendor command. As I see little downside to reference an old version of bender in the documentation, and the bender manifest also seems to reflect a more recent version (use of vendor_package), I have updated the readme to point to the latest stable release (0.28.1), and fixed the example command to revendor the project.

There is still some (tiny) issue in that the patches for the documentation for the lowrisc_titan package can not be properly applied, but I could not be bothered to fix this. This has no impact on the corecctness of the code, as it is only related to the documentation.

Kind regards
Christian