### PR TITLE
regtool: Add subregister writes and packed register type

### DIFF
--- a/vendor/lowrisc_opentitan/util/reggen/bits.py
+++ b/vendor/lowrisc_opentitan/util/reggen/bits.py
@@ -19,6 +19,18 @@ class Bits:
     def bitmask(self) -> int:
         return (1 << (self.msb + 1)) - (1 << self.lsb)
 
+    def bytemask(self) -> int:
+        bytemask = 0
+
+        bitmask = self.bitmask()
+        i = 0
+        while bitmask >= 2**(i*8):
+            if bitmask & (0b1111_1111 << i*8):
+                bytemask |= 1 << i
+            i += 1
+
+        return bytemask
+
     def width(self) -> int:
         return 1 + self.msb - self.lsb
 

--- a/vendor/lowrisc_opentitan/util/reggen/reg_pkg.sv.tpl
+++ b/vendor/lowrisc_opentitan/util/reggen/reg_pkg.sv.tpl
@@ -290,24 +290,29 @@ value = "{}'h {:x}".format(aw, r.offset)
 % endfor
   } ${lpfx}_id_e;
 
-  // Register width information to check illegal writes${for_iface}
-  parameter logic [3:0] ${upfx}_PERMIT [${len(rb.flat_regs)}] = '{
+  // Register bytemaks used to see if a register is to be written to ${for_iface}
+  parameter logic [3:0] ${upfx}_BYTEMASK [${len(rb.flat_regs)}] = '{
   % for i, r in enumerate(rb.flat_regs):
 <%
   index_str = "{}".format(i).rjust(idx_len)
-  width = r.get_width()
-  if width > 24:
-    mask = '1111'
-  elif width > 16:
-    mask = '0111'
-  elif width > 8:
-    mask = '0011'
-  else:
-    mask = '0001'
+  mask = "4'b {:04b}".format(r.bytemask())
 
   comma = ',' if i < len(rb.flat_regs) - 1 else ' '
 %>\
-    4'b ${mask}${comma} // index[${index_str}] ${ublock}_${r.name.upper()}
+    ${mask}${comma} // index[${index_str}] ${ublock}_${r.name.upper()}
+  % endfor
+  };
+
+  // Register boudary crossing infromation to make sure we don't write to half of a field${for_iface}
+  parameter logic [3:0] ${upfx}_DISALLOWED_BOUNDARY_CROSSINGS [${len(rb.flat_regs)}] = '{
+  % for i, r in enumerate(rb.flat_regs):
+<%
+  index_str = "{}".format(i).rjust(idx_len)
+  mask = "3'b " + "{:03b}".format(r.crossed_byte_boundaries())[-3:]
+
+  comma = ',' if i < len(rb.flat_regs) - 1 else ' '
+%>\
+    ${mask}${comma} // index[${index_str}] ${ublock}_${r.name.upper()}
   % endfor
   };
 % endif

--- a/vendor/lowrisc_opentitan/util/reggen/reg_top.sv.tpl
+++ b/vendor/lowrisc_opentitan/util/reggen/reg_top.sv.tpl
@@ -438,7 +438,7 @@ ${finst_gen(f, finst_name, fsig_name, r.hwext, r.regwen, r.shadowed)}
   always_comb begin
     addr_hit = '0;
     % for i,r in enumerate(regs_flat):
-    addr_hit[${"{}".format(i).rjust(max_regs_char)}] = (reg_addr == ${ublock}_${r.name.upper()}_OFFSET);
+    addr_hit[${"{}".format(i).rjust(max_regs_char)}] = ((reg_be & ${ublock}_BYTEMASK[${"{}".format(i).rjust(max_regs_char)}]) && reg_addr == ${ublock}_${r.name.upper()}_OFFSET);
     % endfor
   end
 
@@ -446,11 +446,13 @@ ${finst_gen(f, finst_name, fsig_name, r.hwext, r.regwen, r.shadowed)}
 
 % if regs_flat:
 <%
-    # We want to signal wr_err if reg_be (the byte enable signal) is true for
-    # any bytes that aren't supported by a register. That's true if a
-    # addr_hit[i] and a bit is set in reg_be but not in *_PERMIT[i].
+    # We want to signal wr_err if reg_be wants to write to only part of a field.
+    # This is the case if the byte enable has a border (calculated by `reg_be ^ (reg_be >> 1)`)
+    # at a bit where a field is crossing (DISALLOWED_BOUNDARY_CROSSINGS)
+    # e.g. reg_be `0b0100` has a border at position 2 and 3 (-> `0b110`) and is not allowed to write
+    # to a field with bytemask `0b1100`, which disallows a border at bit position 3 (`0b100`)
 
-    wr_err_terms = ['(addr_hit[{idx}] & (|({mod}_PERMIT[{idx}] & ~reg_be)))'
+    wr_err_terms = ['(addr_hit[{idx}] & (|((reg_be ^ (reg_be >> 1)) & {mod}_DISALLOWED_BOUNDARY_CROSSINGS[{idx}])))'
                     .format(idx=str(i).rjust(max_regs_char),
                             mod=u_mod_base)
                     for i in range(len(regs_flat))]
@@ -770,15 +772,16 @@ ${bits.msb}\
     needs_we = field.swaccess.allows_write()
     needs_re = (field.swaccess.allows_read() and hwext) or shadowed
     space = '\n' if needs_we or needs_re else ''
+    bytemask = "4'b {:04b}".format(field.bits.bytemask())
 %>\
 ${space}\
 % if needs_we:
   % if field.swaccess.swrd() != SwRdAccess.RC:
-  assign ${sig_name}_we = addr_hit[${idx}] & reg_we & !reg_error;
+  assign ${sig_name}_we = addr_hit[${idx}] & reg_we & !reg_error & (|(${bytemask} & reg_be));
   assign ${sig_name}_wd = reg_wdata[${str_bits_sv(field.bits)}];
   % else:
   ## Generate WE based on read request, read should clear
-  assign ${sig_name}_we = addr_hit[${idx}] & reg_re & !reg_error;
+  assign ${sig_name}_we = addr_hit[${idx}] & reg_re & !reg_error & (|(${bytemask} & reg_be));
   assign ${sig_name}_wd = '1;
   % endif
 % endif

--- a/vendor/lowrisc_opentitan/util/reggen/register.py
+++ b/vendor/lowrisc_opentitan/util/reggen/register.py
@@ -285,6 +285,30 @@ class Register(RegBase):
     def is_homogeneous(self) -> bool:
         return len(self.fields) == 1
 
+    def crossed_byte_boundaries(self) -> int:
+        '''
+        Returns the byte boundaries that are crossed by a field contained in this register.
+        e.g. `fields: [ { bits: "23:16" }, { bits: "15:0" } ]`
+        crosses the third and first byte boundary, so it returns 0b101.
+        This is used to determine whether a write using bytestrobe is valid.
+        '''
+        boundaries = 0
+
+        for field in self.fields:
+            bytemask = field.bits.bytemask()
+            boundaries |= bytemask & (bytemask >> 1)
+
+        return boundaries
+
+    def bytemask(self) -> int:
+        bytemask = 0
+
+        for field in self.fields:
+            bytemask |= field.bits.bytemask()
+
+        return bytemask
+
+
     def get_width(self) -> int:
         '''Get the width of the fields in the register in bits
 

--- a/vendor/lowrisc_opentitan/util/reggen/register.py
+++ b/vendor/lowrisc_opentitan/util/reggen/register.py
@@ -91,7 +91,8 @@ class Register(RegBase):
                  shadowed: bool,
                  fields: List[Field],
                  update_err_alert: Optional[str],
-                 storage_err_alert: Optional[str]):
+                 storage_err_alert: Optional[str],
+                 doesnt_increment_offset: bool):
         super().__init__(offset)
         self.name = name
         self.desc = desc
@@ -173,6 +174,7 @@ class Register(RegBase):
 
         self.update_err_alert = update_err_alert
         self.storage_err_alert = storage_err_alert
+        self.doesnt_increment_offset = doesnt_increment_offset
 
     @staticmethod
     def from_raw(reg_width: int,
@@ -261,9 +263,12 @@ class Register(RegBase):
         return Register(offset, name, desc, swaccess, hwaccess,
                         hwext, hwqe, hwre, regwen,
                         tags, resval, shadowed, fields,
-                        update_err_alert, storage_err_alert)
+                        update_err_alert, storage_err_alert, False)
 
     def next_offset(self, addrsep: int) -> int:
+        if self.doesnt_increment_offset:
+            return self.offset
+
         return self.offset + addrsep
 
     def sw_readable(self) -> bool:
@@ -374,7 +379,7 @@ class Register(RegBase):
                         self.swaccess, self.hwaccess,
                         self.hwext, self.hwqe, self.hwre, new_regwen,
                         self.tags, new_resval, self.shadowed, new_fields,
-                        self.update_err_alert, self.storage_err_alert)
+                        self.update_err_alert, self.storage_err_alert, False)
 
     def _asdict(self) -> Dict[str, object]:
         rd = {
@@ -388,6 +393,7 @@ class Register(RegBase):
             'hwre': str(self.hwre),
             'tags': self.tags,
             'shadowed': str(self.shadowed),
+            'doesnt_increment_offset': str(self.doesnt_increment_offset),
         }
         if self.regwen is not None:
             rd['regwen'] = self.regwen


### PR DESCRIPTION
This fork is currently being used in the implementation of the SD Host Controller.

## Subregister Writes
The first commit adds the possibility to for example only write a single byte when reg_width is set to 32.
It returns an error if `reg_be` tries to write only part of a field.

This change is required to make most implementations of a SDHCI driver work.

## Packed Register Type
Since the SDHC contains registers that are 1byte wide as long as ones that are 4 byte wide, we would have to do something like this:
```yml
registers: [
  {
    name: regs1_2_3_and_4
    fields: {
      reg1_field1: { ... }
      reg2_field1: { ... }
      reg3_field1: { ... }
      reg4_field1: { ... }
    }
  }
]
````
Which leads to having to write RTL code like this:
```c
reg2hw.host_and_power_and_block_gap_and_wakeup_control.host_control_high_speed_enable
```

The second commit of this PR adds packed registers, which makes it work nicely like so:
```yml
registers: [
  {
    packed: [
      {
         name: reg1
         fields: [ field1: { ... } ]
      }
      {
         name: reg2
         fields: [ field1: { ... } ]
      }
      {
         name: reg3
         fields: [ field1: { ... } ]
      }
      {
         name: reg4
         fields: [ field1: { ... } ]
      }
    ]
  }
]
````
```c
reg2hw.host_control.high_speed_enable
```

This is not strictly necessary for SDHCI to work, but its easier to work with :)

Note that neither of the two commits were tested on anything but `gen_rtl.py`