### PR TITLE
fix(reg_to_tlul): honor TL-UL A-channel a_ready — prevent duplicate Get on back-to-back transactions

### DIFF
--- a/src/reg_to_tlul.sv
+++ b/src/reg_to_tlul.sv
@@ -18,6 +18,10 @@ module reg_to_tlul #(
   parameter tl_a_op_e PutFullData = '0,
   parameter tl_a_op_e Get = '0
 ) (
+    // Clock/reset — required for the one-outstanding A-channel handshake (see GAP-A9 note below).
+    input  logic    clk_i,
+    input  logic    rst_ni,
+
     // TL-UL interface
     output tl_h2d_t tl_o,
     input  tl_d2h_t tl_i,
@@ -27,8 +31,37 @@ module reg_to_tlul #(
     output rsp_t reg_rsp_o
 );
 
+  // ---------------------------------------------------------------------------------------------
+  // SF-1 GAP-A9 fix — proper one-outstanding TL-UL host A-channel.
+  //
+  // The stock adapter was a fire-and-forget A-channel: `tl_o.a_valid = reg_req_i.valid` with the
+  // reg-side completion derived from `d_valid` ONLY (`reg_rsp_o.ready = tl_i.d_valid`), never
+  // consulting `tl_i.a_ready`. Because the reg-bus holds `valid` until the *response*, `a_valid`
+  // stayed asserted AFTER the device accepted the Get on `a_ready` (which precedes `d_valid` by
+  // >=1 cycle on tlul_adapter_reg), so the device launched a DUPLICATE Get. Under a back-to-back
+  // Get stream — e.g. axi_to_reg_v2 with NumBanks=2 on a 64b-AXI / 32b-reg bridge issues two Gets
+  // per AXI read — the extra in-flight response desynchronises the D-channel and every other read
+  // returns the previous/sibling value (stale). Verified on SF-1 via a core-held tb_axi tap.
+  //
+  // Fix: track exactly ONE outstanding transaction. `a_valid` is suppressed while a request is
+  // accepted-but-unanswered, so the request retires on `a_ready` (acceptance) and is not re-issued
+  // while its response is in flight. Cost: +0 latency, one flop. Backwards-compatible for a single
+  // isolated access (NumBanks=1); only removes the spurious duplicate under pipelined Gets.
+  // Upstream PR: https://github.com/pulp-platform/register_interface/pull/<NN> (see patches/).
+  // ---------------------------------------------------------------------------------------------
+  logic outstanding_q;
+  logic a_ack, d_ack;
+  assign a_ack = tl_o.a_valid & tl_i.a_ready;   // device accepted the A-channel request
+  assign d_ack = tl_i.d_valid & tl_o.d_ready;   // response consumed this cycle
 
-  assign tl_o.a_valid    = reg_req_i.valid;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)               outstanding_q <= 1'b0;
+    else if ( a_ack & !d_ack)  outstanding_q <= 1'b1;   // accepted, awaiting its response
+    else if (!a_ack &  d_ack)  outstanding_q <= 1'b0;   // response done, free to issue again
+    // a_ack & d_ack in the same cycle (latency-0 device): issue+retire, net unchanged.
+  end
+
+  assign tl_o.a_valid    = reg_req_i.valid & ~outstanding_q;  // one outstanding; deassert on accept
   assign tl_o.a_opcode   = reg_req_i.write ? PutFullData : Get;
   assign tl_o.a_param    = '0;
   assign tl_o.a_size     = 'h2;


### PR DESCRIPTION
## Summary

`reg_to_tlul` is a fire-and-forget TL-UL host — it drives `tl_o.a_valid` from `reg_req_i.valid` and derives completion only from the D-channel, **never consulting `tl_i.a_ready`**. This breaks the TileLink-UL A-channel handshake and causes a **duplicate Get** (and silent read-data corruption) on back-to-back transactions to any device that accepts the request on `a_ready` before it returns `d_valid` — the common case. It is synthesizable behaviour (no X/race signature), so it manifests in silicon, not just simulation.

## Problem

TL-UL requires the A-channel master to hold `a_valid` + payload stable until the beat is accepted on `a_ready`, then stop presenting that beat. `reg_to_tlul` instead holds `a_valid` from request issue until the **D-channel** response:

```
assign tl_o.a_valid    = reg_req_i.valid;   // held high until the response
assign reg_rsp_o.ready = tl_i.d_valid;      // completion from D only; a_ready unused
```

Most TL-UL devices accept on `a_ready` one or more cycles before driving `d_valid`. In that window `a_valid` is still high, so the device sees a second valid A-beat and fires a **duplicate Get**. Single isolated accesses often mask this; it bites under **back-to-back / pipelined Gets**, where each duplicate inserts an extra in-flight D beat and desyncs the response stream by one, so alternating reads return the previous/sibling response instead of the requested one.

## Reproduction

Observed in a real SoC where `reg_to_tlul` is fed by `axi_to_reg_v2` with `AxiDataWidth=64 / RegDataWidth=32` (`NumBanks=2` → two back-to-back Gets per AXI read):

- Reads of a live register returned a deterministic, address- and gap-independent alternation `live, 0, live, 0, …`.
- A waveform tap showed two device-side read pulses (duplicate Get) for one reg request, plus an extra `d_valid`, shifting the D stream by one.
- Reproduced with the host core held in reset (driven by a test master asserting exactly one AR beat), isolating the cause to this adapter.

Minimal repro: two back-to-back Gets through `reg_to_tlul` to any device whose `a_ready` leads `d_valid` by ≥1 cycle.

## Fix

Make `reg_to_tlul` a proper **one-outstanding** TL-UL host: track whether a beat has been accepted but not yet answered, and suppress `a_valid` in that window, so a request retires on `a_ready` (not `d_valid`) and is never re-presented while its response is in flight. `+0` latency, one flop.

This adds `clk_i` / `rst_ni` ports (a small interface change). There is no correct *stateless* fix — remembering "this beat is already accepted and awaiting its response" inherently needs one bit of state. Happy to adjust the integration (gating, port naming, a lint/assert for the handshake) to maintainer preference.

## Test

- Post-fix at the same tap: one Get per reg request (duplicate gone), `d_valid` 1:1 with each accepted beat; the alternation is gone — every read returns live data.
- Full-SoC regressions (an OS boot + an interrupt-driven UART-RX path that reads `RDATA`) pass with the previous per-driver software workarounds removed: the exact received byte now reads back through a single plain register read.

Happy to add a small standalone TL-UL handshake testbench (back-to-back Gets to a device with `a_ready` leading `d_valid`) if that's the preferred form for CI.