### PR TITLE
fix(reg_to_tlul): request a full-word a_mask on Get — partial read mask zeroes unrequested byte lanes

### DIFF
--- a/src/reg_to_tlul.sv
+++ b/src/reg_to_tlul.sv
@@ -34,7 +34,7 @@ module reg_to_tlul #(
   assign tl_o.a_size     = 'h2;
   assign tl_o.a_source   = '0;
   assign tl_o.a_address  = reg_req_i.addr;
-  assign tl_o.a_mask     = reg_req_i.wstrb;
+  assign tl_o.a_mask     = reg_req_i.write ? reg_req_i.wstrb : '1;
   assign tl_o.a_data     = reg_req_i.wdata;
   assign tl_o.a_user     = TL_A_USER_DEFAULT;
   assign tl_o.d_ready    = 1'b1;


### PR DESCRIPTION
## Summary
`reg_to_tlul` drives the TL-UL A-channel byte mask from the reg-bus write strobe for **every** request (`assign tl_o.a_mask = reg_req_i.wstrb;`). On a read (`Get`) the write strobe is not a meaningful read mask and may be partial. TL-UL targets that honor `a_mask` on reads (e.g. `tlul_adapter_sram`, which masks `rdata` by `a_mask`) then return only the masked byte lanes and **zero the rest**, silently corrupting sub-word / SRAM-backed reads. CSR targets that ignore the read mask hide the bug.

## Fix
Request the full word on a read; keep the write strobe only for writes:
`assign tl_o.a_mask = reg_req_i.write ? reg_req_i.wstrb : '1;`
`a_size` is fixed at 2 (4 bytes), so `'1` is the full mask. +0 area/latency.

## Notes
Independent, second fix to this module alongside #63 (the A-channel one-outstanding handshake) — different lines, mergeable in any order. Surfaced bringing up a 64-bit-AXI → 32-bit-reg bridge (two Gets per read into an SRAM-backed window). Glad to add a directed TB (partial-mask Get to a mask-honoring SRAM target, assert all lanes return) if preferred.
